### PR TITLE
Add composer merge plugin - issue #9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/dotenv": "^4.4",
         "symfony/flex": "^1.2",
         "symfony/webpack-encore-bundle": "^1.7",
-        "vaachar/sylius-shipping-information-page-plugin": "dev-master"
+        "vaachar/sylius-shipping-information-page-plugin": "dev-master",
+        "wikimedia/composer-merge-plugin": "^1.4"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
@@ -117,6 +118,18 @@
         },
         "branch-alias": {
             "dev-master": "1.7-dev"
-        }
+        },
+        "merge-plugin": {
+            "include": [
+              "themes/*/composer.json"
+            ],
+            "recurse": true,
+            "replace": true,
+            "ignore-duplicates": false,
+            "merge-dev": true,
+            "merge-extra": false,
+            "merge-extra-deep": false,
+            "merge-scripts": false
+          }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18ae0ec86bda4574e2e1c96ca9db7f21",
+    "content-hash": "188084f5f45552797f90a95eaeca0ae0",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -12947,6 +12947,55 @@
             ],
             "abandoned": "babdev/pagerfanta-bundle",
             "time": "2019-12-02T14:19:37+00:00"
+        },
+        {
+            "name": "wikimedia/composer-merge-plugin",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
+                "reference": "81c6ac72a24a67383419c7eb9aa2b3437f2ab100"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/81c6ac72a24a67383419c7eb9aa2b3437f2ab100",
+                "reference": "81c6ac72a24a67383419c7eb9aa2b3437f2ab100",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0.0",
+                "jakub-onderka/php-parallel-lint": "~0.8",
+                "phpunit/phpunit": "~4.8|~5.0",
+                "squizlabs/php_codesniffer": "~2.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                },
+                "class": "Wikimedia\\Composer\\MergePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Composer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Davis",
+                    "email": "bd808@wikimedia.org"
+                }
+            ],
+            "description": "Composer plugin to merge multiple composer.json files",
+            "time": "2017-04-25T02:31:25+00:00"
         },
         {
             "name": "willdurand/hateoas",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "188084f5f45552797f90a95eaeca0ae0",
+    "content-hash": "388a676091b3f962fddeb7bf3a8515b5",
     "packages": [
         {
             "name": "behat/transliterator",

--- a/docs/install-composer-requirements-of-themes.md
+++ b/docs/install-composer-requirements-of-themes.md
@@ -1,0 +1,9 @@
+# How to install composer dependencies of custom themes
+
+In order to install additional composer dependencies you need to add a custom theme to the `themes/` directory with a `composer.json`.
+
+To merge those dependencies with the ones of the main project you need to run `composer update --lock` inside of the php container. (Use `docker exec -it <container_name> sh` to enter the container).
+
+# Adding composer dependencies without a custom theme
+
+Alternatively if you don't use custom themes and still need to add composer dependencies you can just create a new directory in `themes/` and add a `composer.json` just for those dependencies.

--- a/symfony.lock
+++ b/symfony.lock
@@ -1086,6 +1086,9 @@
     "white-october/pagerfanta-bundle": {
         "version": "v1.2.1"
     },
+    "wikimedia/composer-merge-plugin": {
+        "version": "v1.4.1"
+    },
     "willdurand/hateoas": {
         "version": "2.12.0"
     },


### PR DESCRIPTION
This PR adds the [wikimedia/composer-merge-plugin](https://github.com/wikimedia/composer-merge-plugin) to enable the merging of composer requirements of the main project with those of custom themes.

Closes #9 