### PR TITLE
Add plugin for additional product options for customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a Shop built on the [**Sylius Standard Edition**](https://github.com/Syl
 - [**bitbag/cms-plugin**](https://github.com/BitBagCommerce/SyliusCmsPlugin)
 - [**bitbag/mollie-plugin**](https://github.com/BitBagCommerce/SyliusMolliePlugin)
 - [**bitbag/product-bundle-plugin**](https://github.com/BitBagCommerce/SyliusProductBundlePlugin)
+- [**brille24/sylius-customer-options-plugin**](https://github.com/Brille24/SyliusCustomOptionsPlugin)
 - [**joppedc/sylius-better-seo-plugin**](https://github.com/JoppeDC/SyliusBetterSeoPlugin)
 - [**mangoweb-sylius/SyliusContactFormPlugin**](https://github.com/mangoweb-sylius/SyliusContactFormPlugin)
 - [**mangoweb-sylius/sylius-order-comments-plugin**](https://github.com/mangoweb-sylius/SyliusOrderCommentsPlugin)

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "bitbag/cms-plugin": "^2.3",
         "bitbag/mollie-plugin": "^3.2.6",
         "bitbag/product-bundle-plugin": "^1.0",
+        "brille24/sylius-customer-options-plugin": "^2.6",
         "enqueue/enqueue-bundle": "^0.10.1",
         "enqueue/fs": "^0.10.1",
         "enqueue/redis": "^0.10.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83d80cc67faaacd172c579b2f3803339",
+    "content-hash": "a64b5cff157e8c704d60abd18662df5d",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -320,6 +320,74 @@
                 "sylius-plugin"
             ],
             "time": "2020-05-29T13:11:09+00:00"
+        },
+        {
+            "name": "brille24/sylius-customer-options-plugin",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brille24/SyliusCustomOptionsPlugin.git",
+                "reference": "7835add57a1b3a58f09223e670d3b0ea9459d331"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brille24/SyliusCustomOptionsPlugin/zipball/7835add57a1b3a58f09223e670d3b0ea9459d331",
+                "reference": "7835add57a1b3a58f09223e670d3b0ea9459d331",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sylius/sylius": "^1.7"
+            },
+            "conflict": {
+                "symfony/browser-kit": "4.1.8",
+                "symfony/dependency-injection": "4.1.8",
+                "symfony/dom-crawler": "4.1.8",
+                "symfony/routing": "4.1.8",
+                "symfony/symfony": "4.1.8"
+            },
+            "require-dev": {
+                "behat/behat": "^3.6.1",
+                "behat/mink-selenium2-driver": "^1.4",
+                "dmore/behat-chrome-extension": "^1.3",
+                "dmore/chrome-mink-driver": "^2.7",
+                "friends-of-behat/mink": "^1.8",
+                "friends-of-behat/mink-browserkit-driver": "^1.4",
+                "friends-of-behat/mink-extension": "^2.4",
+                "friends-of-behat/page-object-extension": "^0.3",
+                "friends-of-behat/suite-settings-extension": "^1.0",
+                "friends-of-behat/symfony-extension": "^2.1",
+                "friends-of-behat/variadic-extension": "^1.3",
+                "lakion/mink-debug-extension": "^1.2.3",
+                "phpspec/phpspec": "^6.1",
+                "phpstan/phpstan": "^0.10|^0.12",
+                "phpstan/phpstan-doctrine": "^0.10|^0.12",
+                "phpstan/phpstan-strict-rules": "^0.10|^0.12",
+                "phpstan/phpstan-symfony": "^0.10|^0.12",
+                "phpstan/phpstan-webmozart-assert": "^0.10|^0.12",
+                "phpunit/phpunit": "^8.5",
+                "sensiolabs/security-checker": "^6.0",
+                "sylius-labs/coding-standard": "^3.1",
+                "symfony/browser-kit": "^4.4",
+                "symfony/debug-bundle": "^4.4|^5.0",
+                "symfony/dotenv": "^4.4|^5.0",
+                "symfony/intl": "^4.4|^5.0",
+                "symfony/web-profiler-bundle": "^4.4|^5.0",
+                "symfony/web-server-bundle": "^4.4|^5.0"
+            },
+            "type": "sylius-plugin",
+            "autoload": {
+                "psr-4": {
+                    "Brille24\\SyliusCustomerOptionsPlugin\\": "src/",
+                    "Tests\\Brille24\\SyliusCustomerOptionsPlugin\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Adds product customizing to Sylius",
+            "time": "2020-08-04T10:36:20+00:00"
         },
         {
             "name": "clue/stream-filter",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -76,4 +76,5 @@ return [
     Prooph\Bundle\ServiceBus\ProophServiceBusBundle::class => ['all' => true],
     Odiseo\SyliusRbacPlugin\OdiseoSyliusRbacPlugin::class => ['all' => true],
     MangoSylius\SyliusContactFormPlugin\MangoSyliusContactFormPlugin::class => ['all' => true],
+    Brille24\SyliusCustomerOptionsPlugin\Brille24SyliusCustomerOptionsPlugin::class => ['all' => true],
 ];

--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -24,6 +24,8 @@ imports:
 
     - { resource: "@MangoSyliusContactFormPlugin/Resources/config/config.yml" }
 
+    - { resource: "@Brille24SyliusCustomerOptionsPlugin/Resources/config/app/config.yml" }
+
 parameters:
     sylius_core.public_dir: '%kernel.project_dir%/public'
     images_dir: '/media/image/'

--- a/config/routes/brille24_sylius_customer_options_plugin.yaml
+++ b/config/routes/brille24_sylius_customer_options_plugin.yaml
@@ -1,0 +1,2 @@
+brille24_customer_options:
+    resource: "@Brille24SyliusCustomerOptionsPlugin/Resources/config/app/routing.yml"

--- a/src/Entity/Order/OrderItem.php
+++ b/src/Entity/Order/OrderItem.php
@@ -6,6 +6,8 @@ namespace App\Entity\Order;
 
 use BitBag\SyliusProductBundlePlugin\Entity\ProductBundleOrderItemInterface;
 use BitBag\SyliusProductBundlePlugin\Entity\ProductBundleOrderItemsAwareTrait;
+use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemInterface as ProductCustomerOptionOrderItemInterface;
+use Brille24\SyliusCustomerOptionsPlugin\Traits\OrderItemCustomerOptionCapableTrait;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\OrderItem as BaseOrderItem;
 
@@ -13,9 +15,12 @@ use Sylius\Component\Core\Model\OrderItem as BaseOrderItem;
  * @ORM\Entity
  * @ORM\Table(name="sylius_order_item")
  */
-class OrderItem extends BaseOrderItem
+class OrderItem extends BaseOrderItem implements ProductCustomerOptionOrderItemInterface
 {
     use ProductBundleOrderItemsAwareTrait;
+    use OrderItemCustomerOptionCapableTrait {
+        __construct as protected customerOptionCapableConstructor;
+    }
 
     /**
      * @ORM\OneToMany(targetEntity="BitBag\SyliusProductBundlePlugin\Entity\ProductBundleOrderItemInterface", mappedBy="orderItem", cascade={"all"})
@@ -23,4 +28,11 @@ class OrderItem extends BaseOrderItem
      * @var ArrayCollection|ProductBundleOrderItemInterface[]
      */
     protected $productBundleOrderItems;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->customerOptionCapableConstructor();
+    }
 }

--- a/src/Entity/Product/Product.php
+++ b/src/Entity/Product/Product.php
@@ -6,6 +6,8 @@ namespace App\Entity\Product;
 
 use BitBag\SyliusProductBundlePlugin\Entity\ProductBundlesAwareInterface;
 use BitBag\SyliusProductBundlePlugin\Entity\ProductBundlesAwareTrait;
+use Brille24\SyliusCustomerOptionsPlugin\Entity\ProductInterface as ProductCustomerOptionProductInterface;
+use Brille24\SyliusCustomerOptionsPlugin\Traits\ProductCustomerOptionCapableTrait;
 use Doctrine\ORM\Mapping as ORM;
 use JoppeDc\SyliusBetterSeoPlugin\Entity\HasSeoInterface;
 use JoppeDc\SyliusBetterSeoPlugin\Entity\Traits\SeoTrait;
@@ -19,7 +21,7 @@ use Sylius\Component\Product\Model\ProductTranslationInterface;
  * @ORM\Entity
  * @ORM\Table(name="sylius_product")
  */
-class Product extends BaseProduct implements ProductBundlesAwareInterface, DocumentableInterface, HasSeoInterface
+class Product extends BaseProduct implements ProductBundlesAwareInterface, DocumentableInterface, HasSeoInterface, ProductCustomerOptionProductInterface
 {
     use ProductBundlesAwareTrait;
     use DocumentableProductTrait;
@@ -27,6 +29,9 @@ class Product extends BaseProduct implements ProductBundlesAwareInterface, Docum
         convertToDocument as protected traitConvertToDocument;
     }
     use SeoTrait;
+    use ProductCustomerOptionCapableTrait {
+        __construct as protected customerOptionCapableConstructor;
+    }
 
     /**
      * @ORM\OneToOne(targetEntity="BitBag\SyliusProductBundlePlugin\Entity\ProductBundleInterface", mappedBy="product", cascade={"persist"})
@@ -34,6 +39,13 @@ class Product extends BaseProduct implements ProductBundlesAwareInterface, Docum
      * @var ProductBundleInterface
      */
     protected $productBundle;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->customerOptionCapableConstructor();
+    }
 
     protected function createTranslation(): ProductTranslationInterface
     {

--- a/src/Migrations/Version20200829172758.php
+++ b/src/Migrations/Version20200829172758.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200829172758 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE brille24_customer_option_order_item_option (id INT AUTO_INCREMENT NOT NULL, customerOptionCode VARCHAR(255) NOT NULL, customerOptionName VARCHAR(255) NOT NULL, customerOptionType VARCHAR(255) NOT NULL, customerOptionValueCode VARCHAR(255) DEFAULT NULL, customerOptionValueName VARCHAR(255) DEFAULT NULL, optionValue LONGTEXT DEFAULT NULL, fixedPrice INT NOT NULL, percent DOUBLE PRECISION NOT NULL, pricingType VARCHAR(255) NOT NULL, orderItem_id INT DEFAULT NULL, customerOption_id INT DEFAULT NULL, customerOptionValue_id INT DEFAULT NULL, INDEX IDX_8B833EE4E76E9C94 (orderItem_id), INDEX IDX_8B833EE427309983 (customerOption_id), INDEX IDX_8B833EE46ABB6709 (customerOptionValue_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option (id INT AUTO_INCREMENT NOT NULL, type VARCHAR(255) NOT NULL, configuration JSON NOT NULL COMMENT \'(DC2Type:json_array)\', code VARCHAR(255) NOT NULL, required TINYINT(1) NOT NULL, UNIQUE INDEX UNIQ_1E7F7D0677153098 (code), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_value (id INT AUTO_INCREMENT NOT NULL, code VARCHAR(255) NOT NULL, customerOption_id INT DEFAULT NULL, INDEX IDX_65B04D7B27309983 (customerOption_id), UNIQUE INDEX UNIQ_65B04D7B2730998377153098 (customerOption_id, code), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_value_price (id INT AUTO_INCREMENT NOT NULL, channel_id INT DEFAULT NULL, product_id INT DEFAULT NULL, percent DOUBLE PRECISION NOT NULL, amount INT NOT NULL, type VARCHAR(12) NOT NULL, dateValid_id INT DEFAULT NULL, customerOptionValue_id INT DEFAULT NULL, UNIQUE INDEX UNIQ_D218E8EE50552292 (dateValid_id), INDEX IDX_D218E8EE6ABB6709 (customerOptionValue_id), INDEX IDX_D218E8EE72F5A1AA (channel_id), INDEX IDX_D218E8EE4584665A (product_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_group (id INT AUTO_INCREMENT NOT NULL, code VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_group_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT DEFAULT NULL, name VARCHAR(255) DEFAULT NULL, locale VARCHAR(255) NOT NULL, INDEX IDX_DD9F6EB32C2AC5D3 (translatable_id), UNIQUE INDEX brille24_customer_option_group_translation_uniq_trans (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_group_validator (id INT AUTO_INCREMENT NOT NULL, errorMessage_id INT DEFAULT NULL, customerOptionGroup_id INT DEFAULT NULL, UNIQUE INDEX UNIQ_1C13475874E6266C (errorMessage_id), INDEX IDX_1C1347586DCF05EC (customerOptionGroup_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_association (id INT AUTO_INCREMENT NOT NULL, option_id INT NOT NULL, group_id INT NOT NULL, position INT NOT NULL, INDEX IDX_1AF36ED0A7C41D6F (option_id), INDEX IDX_1AF36ED0FE54D947 (group_id), UNIQUE INDEX UNIQ_1AF36ED0A7C41D6FFE54D947 (option_id, group_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_validator_error_message (id INT AUTO_INCREMENT NOT NULL, validator_id INT DEFAULT NULL, UNIQUE INDEX UNIQ_5535DA3B0644AEC (validator_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_group_validator_condition (id INT AUTO_INCREMENT NOT NULL, validator_id INT DEFAULT NULL, comparator VARCHAR(255) NOT NULL, value JSON DEFAULT NULL COMMENT \'(DC2Type:json_array)\', customerOption_id INT DEFAULT NULL, INDEX IDX_B230415EB0644AEC (validator_id), INDEX IDX_B230415E27309983 (customerOption_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_group_validator_constraint (id INT AUTO_INCREMENT NOT NULL, validator_id INT DEFAULT NULL, comparator VARCHAR(255) NOT NULL, value JSON DEFAULT NULL COMMENT \'(DC2Type:json_array)\', customerOption_id INT DEFAULT NULL, INDEX IDX_5A4304E2B0644AEC (validator_id), INDEX IDX_5A4304E227309983 (customerOption_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_validator_error_message_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT DEFAULT NULL, message VARCHAR(255) DEFAULT NULL, locale VARCHAR(255) NOT NULL, INDEX IDX_4E22795E2C2AC5D3 (translatable_id), UNIQUE INDEX brille24_validator_error_message_translation_uniq_trans (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_date_range (id INT AUTO_INCREMENT NOT NULL, start DATETIME NOT NULL, end DATETIME NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT DEFAULT NULL, name VARCHAR(255) DEFAULT NULL, locale VARCHAR(255) NOT NULL, INDEX IDX_531F0A732C2AC5D3 (translatable_id), UNIQUE INDEX brille24_customer_option_translation_uniq_trans (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE brille24_customer_option_value_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT DEFAULT NULL, name VARCHAR(255) DEFAULT NULL, locale VARCHAR(255) NOT NULL, INDEX IDX_3AD2C9512C2AC5D3 (translatable_id), UNIQUE INDEX brille24_customer_option_value_translation_uniq_trans (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE brille24_customer_option_order_item_option ADD CONSTRAINT FK_8B833EE4E76E9C94 FOREIGN KEY (orderItem_id) REFERENCES sylius_order_item (id)');
+        $this->addSql('ALTER TABLE brille24_customer_option_order_item_option ADD CONSTRAINT FK_8B833EE427309983 FOREIGN KEY (customerOption_id) REFERENCES brille24_customer_option (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE brille24_customer_option_order_item_option ADD CONSTRAINT FK_8B833EE46ABB6709 FOREIGN KEY (customerOptionValue_id) REFERENCES brille24_customer_option_value (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE brille24_customer_option_value ADD CONSTRAINT FK_65B04D7B27309983 FOREIGN KEY (customerOption_id) REFERENCES brille24_customer_option (id)');
+        $this->addSql('ALTER TABLE brille24_customer_option_value_price ADD CONSTRAINT FK_D218E8EE50552292 FOREIGN KEY (dateValid_id) REFERENCES brille24_customer_option_date_range (id)');
+        $this->addSql('ALTER TABLE brille24_customer_option_value_price ADD CONSTRAINT FK_D218E8EE6ABB6709 FOREIGN KEY (customerOptionValue_id) REFERENCES brille24_customer_option_value (id)');
+        $this->addSql('ALTER TABLE brille24_customer_option_value_price ADD CONSTRAINT FK_D218E8EE72F5A1AA FOREIGN KEY (channel_id) REFERENCES sylius_channel (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE brille24_customer_option_value_price ADD CONSTRAINT FK_D218E8EE4584665A FOREIGN KEY (product_id) REFERENCES sylius_product (id)');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_translation ADD CONSTRAINT FK_DD9F6EB32C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES brille24_customer_option_group (id)');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator ADD CONSTRAINT FK_1C13475874E6266C FOREIGN KEY (errorMessage_id) REFERENCES brille24_validator_error_message (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator ADD CONSTRAINT FK_1C1347586DCF05EC FOREIGN KEY (customerOptionGroup_id) REFERENCES brille24_customer_option_group (id)');
+        $this->addSql('ALTER TABLE brille24_customer_option_association ADD CONSTRAINT FK_1AF36ED0A7C41D6F FOREIGN KEY (option_id) REFERENCES brille24_customer_option (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE brille24_customer_option_association ADD CONSTRAINT FK_1AF36ED0FE54D947 FOREIGN KEY (group_id) REFERENCES brille24_customer_option_group (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE brille24_validator_error_message ADD CONSTRAINT FK_5535DA3B0644AEC FOREIGN KEY (validator_id) REFERENCES brille24_customer_option_group_validator (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator_condition ADD CONSTRAINT FK_B230415EB0644AEC FOREIGN KEY (validator_id) REFERENCES brille24_customer_option_group_validator (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator_condition ADD CONSTRAINT FK_B230415E27309983 FOREIGN KEY (customerOption_id) REFERENCES brille24_customer_option (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator_constraint ADD CONSTRAINT FK_5A4304E2B0644AEC FOREIGN KEY (validator_id) REFERENCES brille24_customer_option_group_validator (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator_constraint ADD CONSTRAINT FK_5A4304E227309983 FOREIGN KEY (customerOption_id) REFERENCES brille24_customer_option (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE brille24_validator_error_message_translation ADD CONSTRAINT FK_4E22795E2C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES brille24_validator_error_message (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE brille24_customer_option_translation ADD CONSTRAINT FK_531F0A732C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES brille24_customer_option (id)');
+        $this->addSql('ALTER TABLE brille24_customer_option_value_translation ADD CONSTRAINT FK_3AD2C9512C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES brille24_customer_option_value (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_product ADD customerOptionGroup_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_product ADD CONSTRAINT FK_677B9B746DCF05EC FOREIGN KEY (customerOptionGroup_id) REFERENCES brille24_customer_option_group (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_677B9B746DCF05EC ON sylius_product (customerOptionGroup_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE brille24_customer_option_order_item_option DROP FOREIGN KEY FK_8B833EE427309983');
+        $this->addSql('ALTER TABLE brille24_customer_option_value DROP FOREIGN KEY FK_65B04D7B27309983');
+        $this->addSql('ALTER TABLE brille24_customer_option_association DROP FOREIGN KEY FK_1AF36ED0A7C41D6F');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator_condition DROP FOREIGN KEY FK_B230415E27309983');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator_constraint DROP FOREIGN KEY FK_5A4304E227309983');
+        $this->addSql('ALTER TABLE brille24_customer_option_translation DROP FOREIGN KEY FK_531F0A732C2AC5D3');
+        $this->addSql('ALTER TABLE brille24_customer_option_order_item_option DROP FOREIGN KEY FK_8B833EE46ABB6709');
+        $this->addSql('ALTER TABLE brille24_customer_option_value_price DROP FOREIGN KEY FK_D218E8EE6ABB6709');
+        $this->addSql('ALTER TABLE brille24_customer_option_value_translation DROP FOREIGN KEY FK_3AD2C9512C2AC5D3');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_translation DROP FOREIGN KEY FK_DD9F6EB32C2AC5D3');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator DROP FOREIGN KEY FK_1C1347586DCF05EC');
+        $this->addSql('ALTER TABLE brille24_customer_option_association DROP FOREIGN KEY FK_1AF36ED0FE54D947');
+        $this->addSql('ALTER TABLE sylius_product DROP FOREIGN KEY FK_677B9B746DCF05EC');
+        $this->addSql('ALTER TABLE brille24_validator_error_message DROP FOREIGN KEY FK_5535DA3B0644AEC');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator_condition DROP FOREIGN KEY FK_B230415EB0644AEC');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator_constraint DROP FOREIGN KEY FK_5A4304E2B0644AEC');
+        $this->addSql('ALTER TABLE brille24_customer_option_group_validator DROP FOREIGN KEY FK_1C13475874E6266C');
+        $this->addSql('ALTER TABLE brille24_validator_error_message_translation DROP FOREIGN KEY FK_4E22795E2C2AC5D3');
+        $this->addSql('ALTER TABLE brille24_customer_option_value_price DROP FOREIGN KEY FK_D218E8EE50552292');
+        $this->addSql('DROP TABLE brille24_customer_option_order_item_option');
+        $this->addSql('DROP TABLE brille24_customer_option');
+        $this->addSql('DROP TABLE brille24_customer_option_value');
+        $this->addSql('DROP TABLE brille24_customer_option_value_price');
+        $this->addSql('DROP TABLE brille24_customer_option_group');
+        $this->addSql('DROP TABLE brille24_customer_option_group_translation');
+        $this->addSql('DROP TABLE brille24_customer_option_group_validator');
+        $this->addSql('DROP TABLE brille24_customer_option_association');
+        $this->addSql('DROP TABLE brille24_validator_error_message');
+        $this->addSql('DROP TABLE brille24_customer_option_group_validator_condition');
+        $this->addSql('DROP TABLE brille24_customer_option_group_validator_constraint');
+        $this->addSql('DROP TABLE brille24_validator_error_message_translation');
+        $this->addSql('DROP TABLE brille24_customer_option_date_range');
+        $this->addSql('DROP TABLE brille24_customer_option_translation');
+        $this->addSql('DROP TABLE brille24_customer_option_value_translation');
+        $this->addSql('DROP INDEX IDX_677B9B746DCF05EC ON sylius_product');
+        $this->addSql('ALTER TABLE sylius_product DROP customerOptionGroup_id');
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -35,6 +35,9 @@
     "bitbag/product-bundle-plugin": {
         "version": "v1.0.0"
     },
+    "brille24/sylius-customer-options-plugin": {
+        "version": "2.6.1"
+    },
     "clue/stream-filter": {
         "version": "v1.4.0"
     },

--- a/templates/bundles/SyliusAdminBundle/Order/Show/Summary/_item.html.twig
+++ b/templates/bundles/SyliusAdminBundle/Order/Show/Summary/_item.html.twig
@@ -1,0 +1,63 @@
+{% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
+
+{% set orderPromotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT') %}
+{% set unitPromotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT') %}
+{% set shippingAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::SHIPPING_ADJUSTMENT') %}
+{% set taxAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::TAX_ADJUSTMENT') %}
+{% set customerOptionAdjustment = constant('Brille24\\SyliusCustomerOptionsPlugin\\Services\\CustomerOptionRecalculator::CUSTOMER_OPTION_ADJUSTMENT') %}
+
+{% set variant = item.variant %}
+{% set product = variant.product %}
+
+{% set aggregatedUnitPromotionAdjustments = item.getAdjustmentsTotalRecursively(unitPromotionAdjustment) + item.getAdjustmentsTotalRecursively(orderPromotionAdjustment) %}
+{% set subtotal = (item.unitPrice * item.quantity) + aggregatedUnitPromotionAdjustments %}
+
+{% set taxIncluded = sylius_admin_order_unit_tax_included(item) %}
+{% set taxExcluded = sylius_admin_order_unit_tax_excluded(item) %}
+
+<tr>
+    <td class="single line">
+        {% include '@SyliusAdmin/Product/_info.html.twig' %}
+        {% if item.customerOptionConfiguration is defined %}
+            {% include '@Brille24SyliusCustomerOptionsPlugin/Product/_customerOptions.html.twig' with {
+                'configuration': item.customerOptionConfiguration
+            } %}
+            {% if item.order.state != constant('Sylius\\Component\\Order\\Model\\Order::STATE_CANCELLED') %}
+                <a href="{{ path('edit_order_item_configuration', {'orderItem': item.id}) }}" class="button ui">
+                    {{ 'brille24.ui.customer_options'|trans }}
+                </a>
+            {% endif %}
+        {% endif %}
+    </td>
+    <td class="right aligned unit-price">
+        {{ money.format(item.unitPrice, order.currencyCode) }}
+        + {{ money.format(item.getAdjustmentsTotalRecursively(customerOptionAdjustment), order.currencyCode) }}
+    </td>
+    <td class="right aligned unit-order-discount">
+        <span style="font-style: italic;">~ {{ money.format(item.units.first.adjustmentsTotal(orderPromotionAdjustment), order.currencyCode) }}</span>
+    </td>
+    <td class="right aligned discounted-unit-price">
+        {{ money.format(item.discountedUnitPrice, order.currencyCode) }}
+    </td>
+    <td class="right aligned discounted-unit-price">
+        {{ money.format(item.fullDiscountedUnitPrice, order.currencyCode) }}
+    </td>
+    <td class="right aligned quantity">
+        {{ item.quantity }}
+    </td>
+    <td class="right aligned subtotal">
+        {{ money.format(subtotal, order.currencyCode) }}
+    </td>
+    <td class="right aligned tax">
+        <div class="tax-excluded">{{ money.format(taxExcluded, order.currencyCode) }}</div>
+        <div class="tax-disabled">
+            <div class="tax-included"> {{ money.format(taxIncluded, order.currencyCode) }}
+            </div>
+            <small>({{ 'sylius.ui.included_in_price'|trans }})</small>
+        </div>
+    </td>
+    <td class="right aligned total">
+        {{ money.format(item.total, order.currencyCode) }}
+        <span class="tax-disabled">+ {{ money.convertAndFormat(item.getAdjustmentsTotalRecursively(customerOptionAdjustment)) }}</span>
+    </td>
+</tr>

--- a/templates/bundles/SyliusShopBundle/Cart/Summary/_item.html.twig
+++ b/templates/bundles/SyliusShopBundle/Cart/Summary/_item.html.twig
@@ -1,0 +1,37 @@
+{% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
+
+{% set product = item.product %}
+{% set product_variant = item.variant %}
+{% set customerOptionAdjustment = constant('Brille24\\SyliusCustomerOptionsPlugin\\Services\\CustomerOptionRecalculator::CUSTOMER_OPTION_ADJUSTMENT') %}
+
+<tr {{ sylius_test_html_attribute('cart-product-row', item.productName) }}>
+    <td class="single line" {{ sylius_test_html_attribute('cart-item', loop_index|default(null) ) }}>
+        {% include '@SyliusShop/Product/_info.html.twig' with {
+            'variant': product_variant,
+            'configuration': item.customerOptionConfiguration
+        } %}
+    </td>
+    <td class="right aligned">
+        {% if item.unitPrice != item.discountedUnitPrice %}
+            <span class="sylius-regular-unit-price" {{ sylius_test_html_attribute('cart-product-regular-unit-price') }}>
+                <span class="old-price">{{ money.convertAndFormat(item.unitPrice) }}</span>
+            </span>
+        {% endif %}
+        <span class="sylius-unit-price" {{ sylius_test_html_attribute('cart-product-unit-price', item.productName) }}>{{ money.convertAndFormat(item.discountedUnitPrice) }}</span>
+    </td>
+    <td class="center aligned">
+        <span class="sylius-quantity ui form">{{ form_widget(form.quantity, sylius_test_form_attribute('cart-item-quantity-input', item.productName)|sylius_merge_recursive({'attr': {'form': main_form}})) }}</span>
+    </td>
+    <td class="center aligned">
+        <form action="{{ path('sylius_shop_cart_item_remove', {'id': item.id}) }}" method="post">
+            <input type="hidden" name="_method" value="DELETE" />
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token(item.id) }}" />
+            <button type="submit" class="ui circular icon button sylius-cart-remove-button" {{ sylius_test_html_attribute('cart-remove-button', item.productName) }} ><i class="remove icon"></i></button>
+        </form>
+    </td>
+    <td class="right aligned">
+        <span class="sylius-total" {{ sylius_test_html_attribute('cart-product-subtotal') }}>{{ money.convertAndFormat(item.subtotal) }}</span>
+        <br />
+        <span class="tax-disabled">+ {{ money.convertAndFormat(item.getAdjustmentsTotalRecursively(customerOptionAdjustment)) }}</span>
+    </td>
+</tr>

--- a/templates/bundles/SyliusShopBundle/Cart/Summary/_totals.html.twig
+++ b/templates/bundles/SyliusShopBundle/Cart/Summary/_totals.html.twig
@@ -1,0 +1,69 @@
+{% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
+
+{% set itemsSubtotal = sylius_order_items_subtotal(cart) %}
+{% set taxIncluded = sylius_order_tax_included(cart) %}
+{% set taxExcluded = sylius_order_tax_excluded(cart) %}
+{% set customerOptionAdjustment = constant('Brille24\\SyliusCustomerOptionsPlugin\\Services\\CustomerOptionRecalculator::CUSTOMER_OPTION_ADJUSTMENT') %}
+
+<div class="ui segment">
+    <h2 class="ui dividing header">{{ 'sylius.ui.summary'|trans }}</h2>
+
+    {{ sylius_template_event('sylius.shop.cart.summary.totals', {'cart': cart}) }}
+
+    <table class="ui very basic table">
+        <tbody>
+        <tr>
+            <td>{{ 'sylius.ui.items_total'|trans }}:</td>
+            <td class="right aligned">{{ money.convertAndFormat(itemsSubtotal) }}</td>
+        </tr>
+        <tr>
+            <td>{{ 'brille24.ui.customization_total'|trans }}:</td>
+            <td class="right aligned">{{ money.convertAndFormat(cart.getAdjustmentsTotalRecursively(customerOptionAdjustment)) }}</td>
+        </tr>
+        {% if cart.orderPromotionTotal %}
+            <tr>
+                <td>{{ 'sylius.ui.discount'|trans }}:</td>
+                <td id="sylius-cart-promotion-total" {{ sylius_test_html_attribute('cart-promotion-total') }} class="right aligned">{{ money.convertAndFormat(cart.orderPromotionTotal) }}</td>
+            </tr>
+        {% endif %}
+        {% if cart.shipments is not empty %}
+            <tr>
+                <td>{{ 'sylius.ui.shipping_estimated_cost'|trans }}:</td>
+                <td class="right aligned">
+                    {% if cart.getAdjustmentsTotal('shipping') > cart.shippingTotal %}
+                        <span class="old-price">{{ money.convertAndFormat(cart.getAdjustmentsTotal('shipping')) }}</span>
+                    {% endif %}
+                    <span id="sylius-cart-shipping-total" {{ sylius_test_html_attribute('cart-shipping-total') }}>{{ money.convertAndFormat(cart.shippingTotal) }}</span>
+                </td>
+            </tr>
+        {% endif %}
+        <tr {% if taxIncluded and not taxExcluded %}class="tax-disabled"{% endif %}>
+            <td>{{ 'sylius.ui.taxes_total'|trans }}:</td>
+            <td class="right aligned">
+                {% if not taxIncluded and not taxExcluded %}
+                    <div id="sylius-cart-tax-none" {{ sylius_test_html_attribute('cart-no-tax') }}>{{ money.convertAndFormat(0) }}</div>
+                {% endif %}
+                {% if taxExcluded %}
+                    <div id="sylius-cart-tax-excluded" {{ sylius_test_html_attribute('cart-tax-exluded') }}>{{ money.convertAndFormat(taxExcluded) }}</div>
+                {% endif %}
+                {% if taxIncluded %}
+                    <div class="tax-disabled">
+                        <small>({{ 'sylius.ui.included_in_price'|trans }})</small>
+                        <span id="sylius-cart-tax-included" {{ sylius_test_html_attribute('cart-tax-included') }}>{{ money.convertAndFormat(taxIncluded) }}</span>
+                    </div>
+                {% endif %}
+            </td>
+        </tr>
+        <tr class="ui large header">
+            <td>{{ 'sylius.ui.order_total'|trans }}:</td>
+            <td id="sylius-cart-grand-total" {{ sylius_test_html_attribute('cart-grand-total') }} class="right aligned">{{ money.convertAndFormat(cart.total) }}</td>
+        </tr>
+        {% if cart.currencyCode is not same as(sylius.currencyCode) %}
+            <tr>
+                <td>{{ 'sylius.ui.base_currency_order_total'|trans }}:</td>
+                <td id="sylius-cart-base-grand-total" {{ sylius_test_html_attribute('cart-base-grand-total') }} class="right aligned">{{ money.format(cart.total, cart.currencyCode) }}</td>
+            </tr>
+        {% endif %}
+        </tbody>
+    </table>
+</div>

--- a/templates/bundles/SyliusShopBundle/Checkout/_summary.html.twig
+++ b/templates/bundles/SyliusShopBundle/Checkout/_summary.html.twig
@@ -1,0 +1,97 @@
+{% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
+
+{% set itemsSubtotal = sylius_order_items_subtotal(order) %}
+{% set taxIncluded = sylius_order_tax_included(order) %}
+{% set taxExcluded = sylius_order_tax_excluded(order) %}
+{% set customerOptionAdjustment = constant('Brille24\\SyliusCustomerOptionsPlugin\\Services\\CustomerOptionRecalculator::CUSTOMER_OPTION_ADJUSTMENT') %}
+
+<div class="ui segment">
+    <table class="ui very basic table" id="sylius-checkout-subtotal" {{ sylius_test_html_attribute('checkout-subtotal') }}>
+        <thead>
+        <tr>
+            <th class="sylius-table-column-item">{{ 'sylius.ui.item'|trans }}</th>
+            <th class="sylius-table-column-qty">{{ 'sylius.ui.qty'|trans }}</th>
+            <th class="sylius-table-column-subtotal">{{ 'sylius.ui.subtotal'|trans }}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for item in order.items %}
+            <tr>
+                <td>{{ item.getVariant.product.name }}</td>
+                <td class="center aligned">
+                    {{ item.quantity }}
+                </td>
+                <td class="right aligned" id="sylius-item-{{ item.variant.product.slug }}-subtotal" {{ sylius_test_html_attribute('item-subtotal', item.variant.product.slug) }}>
+                    {{ money.convertAndFormat(item.subtotal) }}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        <tfoot>
+        <tr>
+            <td colspan="1" style="border-top: 2px solid #ddd;">
+                <strong>{{ 'sylius.ui.items_total'|trans }}:</strong>
+            </td>
+            <td colspan="2" id="sylius-summary-items-subtotal" class="right aligned" style="border-top: 2px solid #ddd;">
+                {{ money.convertAndFormat(itemsSubtotal) }}
+            </td>
+        </tr>
+        <tr>
+            <td colspan="1">
+                <strong>{{ 'brille24.ui.customization_total'|trans }}:</strong>
+            </td>
+            <td colspan="2" id="sylius-summary-customizations-subtotal" class="right aligned">
+                {{ money.convertAndFormat(order.getAdjustmentsTotalRecursively(customerOptionAdjustment)) }}
+            </td>
+        </tr>
+        <tr {% if taxIncluded and not taxExcluded %}class="tax-disabled" {% endif %}>
+            <td colspan="1">
+                <strong>{{ 'sylius.ui.taxes_total'|trans }}:</strong>
+            </td>
+            <td colspan="2" class="right aligned">
+                {% if not taxIncluded and not taxExcluded %}
+                    <div id="sylius-summary-tax-none">{{ money.convertAndFormat(0) }}</div>
+                {% endif %}
+                {% if taxExcluded %}
+                    <div id="sylius-summary-tax-excluded">{{ money.convertAndFormat(taxExcluded) }}</div>
+                {% endif %}
+                {% if taxIncluded %}
+                    <div class="tax-disabled">
+                        <span id="sylius-summary-tax-included">{{ money.convertAndFormat(taxIncluded) }}</span>
+                        <div><small>({{ 'sylius.ui.included_in_price'|trans }})</small></div>
+                    </div>
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
+            <td colspan="1">
+                <strong>{{ 'sylius.ui.discount'|trans }}:</strong>
+            </td>
+            <td colspan="2" id="sylius-summary-promotion-total" class="right aligned">
+                {{ money.convertAndFormat(order.orderPromotionTotal) }}
+            </td>
+        </tr>
+        {% if order.shipments is not empty %}
+            <tr>
+                <td colspan="1">
+                    <strong>{{ 'sylius.ui.shipping_estimated_cost'|trans }}:</strong>
+                </td>
+                <td colspan="2" class="right aligned">
+                    {% if order.getAdjustmentsTotal('shipping') > order.shippingTotal %}
+                        <div class="old-price">{{ money.convertAndFormat(order.getAdjustmentsTotal('shipping')) }}</div>
+                    {% endif %}
+                    <span id="sylius-summary-shipping-total">{{ money.convertAndFormat(order.shippingTotal) }}</span>
+                </td>
+            </tr>
+        {% endif %}
+        <tr class="ui large header">
+            <td colspan="1">
+                <strong>{{ 'sylius.ui.order_total'|trans }}:</strong>
+            </td>
+            <td colspan="2" id="sylius-summary-grand-total" class="right aligned">
+                {{ money.convertAndFormat(order.total) }}
+            </td>
+        </tr>
+        </tfoot>
+    </table>
+</div>

--- a/templates/bundles/SyliusShopBundle/Common/Order/Table/_item.html.twig
+++ b/templates/bundles/SyliusShopBundle/Common/Order/Table/_item.html.twig
@@ -1,0 +1,26 @@
+{% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
+
+{% set unitPromotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT') %}
+{% set unitPromotions = item.units.first.adjustments(unitPromotionAdjustment) %}
+<tr {{ sylius_test_html_attribute('product-row', item.productName) }}>
+    <td>
+        {% include '@SyliusShop/Product/_info.html.twig' with {
+            'variant': item.variant,
+            'configuration': item.customerOptionConfiguration
+        } %}
+    </td>
+    <td>
+        {% if item.unitPrice != item.discountedUnitPrice %}
+            <span class="old-price" {{ sylius_test_html_attribute('product-old-price', item.productName) }}>{{ money.convertAndFormat(item.unitPrice) }}</span>
+        {% endif %}
+        <span class="sylius-unit-price" {{ sylius_test_html_attribute('product-unit-price', item.productName) }}>{{ money.convertAndFormat(item.discountedUnitPrice) }}
+            {% if item.unitPrice != item.discountedUnitPrice %}
+                <i id="item-promotion-details" class="question circle icon unit-promotions popup-js"
+                   data-html="{% for promotion in unitPromotions %}<div>{{ promotion.label }}: {{ money.convertAndFormat(promotion.amount) }}</div>{% endfor %}">
+            </i>
+            {% endif %}
+        </span>
+    </td>
+    <td class="center aligned">{{ item.quantity }}</td>
+    <td class="right aligned">{{ money.convertAndFormat(item.subtotal) }}</td>
+</tr>

--- a/templates/bundles/SyliusShopBundle/Common/Order/Table/_totals.html.twig
+++ b/templates/bundles/SyliusShopBundle/Common/Order/Table/_totals.html.twig
@@ -1,0 +1,69 @@
+{% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
+
+{% set itemsSubtotal = sylius_order_items_subtotal(order) %}
+{% set taxIncluded = sylius_order_tax_included(order) %}
+{% set taxExcluded = sylius_order_tax_excluded(order) %}
+
+{% set orderPromotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT') %}
+{% set customerOptionAdjustment = constant('Brille24\\SyliusCustomerOptionsPlugin\\Services\\CustomerOptionRecalculator::CUSTOMER_OPTION_ADJUSTMENT') %}
+{% set orderPromotions = sylius_aggregate_adjustments(order.adjustmentsRecursively(orderPromotionAdjustment)) %}
+
+<tr>
+    <th colspan="4" class="right aligned" id="customer-option-total">
+            {{ 'brille24.ui.customization_total'|trans }}: {{ money.convertAndFormat(order.getAdjustmentsTotalRecursively(customerOptionAdjustment)) }}
+        </th>
+    </tr>
+    <tr>
+    <th colspan="4" class="right aligned" id="subtotal" {{ sylius_test_html_attribute('subtotal') }}>
+        {{ 'sylius.ui.items_total'|trans }}: {{ money.convertAndFormat(itemsSubtotal) }}
+    </th>
+</tr>
+<tr{% if taxIncluded and not taxExcluded %}class="tax-disabled"{% endif %}>
+    <td colspan="4" class="right aligned" id="tax-total">
+        <div style="display: flex; justify-content: flex-end; align-items: center">
+            <div>{{ 'sylius.ui.taxes_total'|trans }}:&nbsp;</div>
+            <div data-test="tax-total" {{ sylius_test_html_attribute('tax-total') }}>
+            {% if not taxIncluded and not taxExcluded %}
+                <div id="sylius-cart-tax-none">{{ money.convertAndFormat(0) }}</div>
+            {% endif %}
+            {% if taxExcluded %}
+                <div id="sylius-cart-tax-excluded">{{ money.convertAndFormat(taxExcluded) }}</div>
+            {% endif %}
+            {% if taxIncluded %}
+                <div class="tax-disabled">
+                    <small>({{ 'sylius.ui.included_in_price'|trans }})</small>
+                    <span id="sylius-cart-tax-included">{{ money.convertAndFormat(taxIncluded) }}</span>
+                </div>
+            {% endif %}
+            </div>
+        </div>
+    </td>
+</tr>
+<tr>
+    <td colspan="4" id="promotion-total" class="right aligned" {{ sylius_test_html_attribute('promotion-total') }}>
+        {{ 'sylius.ui.discount'|trans }}: {{ money.convertAndFormat(order.orderPromotionTotal)  }}
+        {% if order.orderPromotionTotal != 0 %}
+            <i
+                id="order-promotions-details" class="question circle icon popup-js"
+                {{ sylius_test_html_attribute('order-promotions-details') }}
+                data-html="{% for key, value in orderPromotions %}<div>{{ key }}: {{ money.convertAndFormat(value) }}</div>{% endfor %}"
+            >
+            </i>
+        {% endif %}
+    </td>
+</tr>
+<tr>
+    {% include '@SyliusShop/Common/Order/Table/_shipping.html.twig' with {'order': order} %}
+</tr>
+<tr>
+    <td colspan="4" class="right aligned" style="font-size: 1.5em;" id="total" {{ sylius_test_html_attribute('order-total') }}>
+        {{ 'sylius.ui.total'|trans }}: {{ money.convertAndFormat(order.total) }}
+    </td>
+</tr>
+{% if order.currencyCode is not same as(sylius.currencyCode) %}
+    <tr>
+        <td colspan="4" class="right aligned" id="base-total" {{ sylius_test_html_attribute('summary-order-total') }}>
+            {{ 'sylius.ui.total_in_base_currency'|trans }}: {{ money.format(order.total, order.currencyCode) }}
+        </td>
+    </tr>
+{% endif %}

--- a/templates/bundles/SyliusShopBundle/Product/Show/_addToCart.html.twig
+++ b/templates/bundles/SyliusShopBundle/Product/Show/_addToCart.html.twig
@@ -1,0 +1,28 @@
+{% set product = order_item.variant.product %}
+
+{% form_theme form '@SyliusShop/Form/theme.html.twig' %}
+
+<div class="ui segment" id="sylius-product-selecting-variant" {{ sylius_test_html_attribute('product-selecting-variant') }}>
+    {{ sylius_template_event('sylius.shop.product.show.before_add_to_cart', {'product': product, 'order_item': order_item}) }}
+
+    {{ form_start(form, {'action': path('sylius_shop_ajax_cart_add_item', {'productId': product.id}), 'attr': {'id': 'sylius-product-adding-to-cart', 'class': 'ui loadable form', 'novalidate': 'novalidate', 'data-redirect': path(configuration.getRedirectRoute('summary'))}}) }}
+    {{ form_errors(form) }}
+    <div class="ui red label bottom pointing hidden sylius-validation-error" id="sylius-cart-validation-error" {{ sylius_test_html_attribute('cart-validation-error') }}></div>
+    {% if not product.simple %}
+        {% if product.variantSelectionMethodChoice %}
+            {% include '@SyliusShop/Product/Show/_variants.html.twig' %}
+        {% else %}
+            {% include '@SyliusShop/Product/Show/_options.html.twig' %}
+        {% endif %}
+    {% endif %}
+
+    {% include '@Brille24SyliusCustomerOptionsPlugin/Product/Shop/_customerOptions.html.twig' %}
+
+    {{ form_row(form.cartItem.quantity, sylius_test_form_attribute('quantity')) }}
+
+    {{ sylius_template_event('sylius.shop.product.show.add_to_cart_form', {'product': product, 'order_item': order_item}) }}
+
+    <button type="submit" class="ui huge primary icon labeled button" {{ sylius_test_html_attribute('add-to-cart-button') }}><i class="cart icon"></i> {{ 'sylius.ui.add_to_cart'|trans }}</button>
+    {{ form_row(form._token) }}
+    {{ form_end(form, {'render_rest': false}) }}
+</div>

--- a/templates/bundles/SyliusShopBundle/Product/_info.html.twig
+++ b/templates/bundles/SyliusShopBundle/Product/_info.html.twig
@@ -1,0 +1,32 @@
+{% set product = variant.product %}
+
+<div class="ui header">
+    {% if variant.hasImages %}
+        {% include '@SyliusShop/Product/_mainImage.html.twig' with {'product': variant, 'filter': 'sylius_shop_product_tiny_thumbnail'} %}
+    {% else %}
+        {% include '@SyliusShop/Product/_mainImage.html.twig' with {'product': product, 'filter': 'sylius_shop_product_tiny_thumbnail'} %}
+    {% endif %}
+    <div class="content">
+        <div class="sylius-product-name" {{ sylius_test_html_attribute('product-name', item.productName) }}>{{ item.productName }}</div>
+        <span class="sub header sylius-product-variant-code" {{ sylius_test_html_attribute('product-variant-code') }}>
+            {{ variant.code }}
+        </span>
+    </div>
+</div>
+{% if product.hasOptions() %}
+    <div class="ui horizontal divided list sylius-product-options" {{ sylius_test_html_attribute('product-options') }}>
+        {% for optionValue in variant.optionValues %}
+            <div class="item" data-sylius-option-name="{{ optionValue.name }}" {{ sylius_test_html_attribute('option-name', optionValue.name) }}>
+                {{ optionValue.value }}
+            </div>
+        {% endfor %}
+    </div>
+{% elseif item.variantName is not null %}
+    <div class="ui horizontal divided list">
+        <div class="item sylius-product-variant-name" {{ sylius_test_html_attribute('product-variant-name') }}>
+            {{ item.variantName }}
+        </div>
+    </div>
+{% endif %}
+
+{% include '@Brille24SyliusCustomerOptionsPlugin/Product/_customerOptions.html.twig' with configuration %}

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -216,5 +216,11 @@ mango_contact_form_plugin:
         detailTitle: 'Nachrichten von %customerName%'
         messages: 'Nachrichten'
         new_message: 'Neue Nachricht'
-        show_message: "Zeige Nachricht"
+        show_message: 'Zeige Nachricht'
 
+brille24:
+    form:
+        config:
+            multiple: Mehrere
+    ui:
+        customization_total: Summe für Anpassungen


### PR DESCRIPTION
This PR adds the brille24/sylius-customer-options-plugin with templates and configuration for additional product options. This enables customers to provide additional input for a product (a file upload for an image, some text that should be on the product, etc.).

Closes #17 